### PR TITLE
Upgrade to CH Api v2 and add fields from jira cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _testmain.go
 *.xml
 *.json
 notes.txt
+venv
+SearchRequest.xml*

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ switch item.Status {
 
 To get your Clubhouse workflow state IDs, you can look at `curl -X GET \
   -H "Content-Type: application/json" \
-  -L "https://api.clubhouse.io/api/v1/workflows?token=$CLUBHOUSE_API_TOKEN"`
+  -L "https://api.clubhouse.io/api/v2/workflows?token=$CLUBHOUSE_API_TOKEN"`
 
 ## Export
 To see what the data will look like (as JSON).

--- a/clubhouseStructs.go
+++ b/clubhouseStructs.go
@@ -26,6 +26,9 @@ type ClubHouseCreateComment struct {
 type ClubHouseCreateStory struct {
 	Comments    	[]ClubHouseCreateComment `json:"comments"`
 	CreatedAt   	time.Time                `json:"created_at"`
+	UpdatedAt   	time.Time                `json:"updated_at"`
+	CompletedAt   	time.Time                `json:"completed_at_override"`
+	StartedAt   	time.Time                `json:"started_at_override"`
 	Description 	string                   `json:"description"`
 	Estimate    	int64                    `json:"estimate"`
 	EpicID      	int64                    `json:"epic_id,omitempty"`

--- a/createTestStory.py
+++ b/createTestStory.py
@@ -12,7 +12,7 @@ try:
 		'project_id':299,
 		'owner_ids':[]
 	}
-	r = requests.post('https://api.clubhouse.io/api/v1/stories', params={'token':token}, data=data)
+	r = requests.post('https://api.clubhouse.io/api/v2/stories', params={'token':token}, data=data)
 	print r.text()
 except RequestException as err:
 	print err

--- a/deleteArchivedStories.py
+++ b/deleteArchivedStories.py
@@ -8,7 +8,7 @@ token = sys.argv[1]
 
 try:
 	search = {'archived':'true'}
-	r = requests.post('https://api.clubhouse.io/api/v1/stories/search', params={'token':token}, data=search)
+	r = requests.post('https://api.clubhouse.io/api/v2/stories/search', params={'token':token}, data=search)
 except RequestException as err:
 	print err
 
@@ -20,7 +20,7 @@ print "Found %d archived stories" % len(archivedStories)
 
 for story in archivedStories:
 	print 'Deleting Story #%d' % story['id']
-	url = 'https://api.clubhouse.io/api/v1/stories/%d' % story['id']
+	url = 'https://api.clubhouse.io/api/v2/stories/%d' % story['id']
 	try:
 		r = requests.delete(url, params={'token':token})
 	except RequestException as err:

--- a/deleteEmptyEpics.py
+++ b/deleteEmptyEpics.py
@@ -7,7 +7,7 @@ import json
 token = sys.argv[1]
 
 try:
-	r = requests.get('https://api.clubhouse.io/api/v1/epics', params={'token':token})
+	r = requests.get('https://api.clubhouse.io/api/v2/epics', params={'token':token})
 except RequestException as err:
 	print err
 
@@ -19,7 +19,7 @@ print "Found %d epics" % len(epic_ids)
 for eid in epic_ids:
 	try:
 		search = {'epic_id':eid}
-		r = requests.post('https://api.clubhouse.io/api/v1/stories/search', params={'token':token}, data=search)
+		r = requests.post('https://api.clubhouse.io/api/v2/stories/search', params={'token':token}, data=search)
 	except RequestException as err:
 		print err
 
@@ -28,6 +28,6 @@ for eid in epic_ids:
 
 	if(len(stories) == 0):
 		# delete this epic
-		url = 'https://api.clubhouse.io/api/v1/epics/%d' % eid
+		url = 'https://api.clubhouse.io/api/v2/epics/%d' % eid
 		print "Deleting epic #%d" % eid
 		r = requests.delete(url, params={'token':token})

--- a/jiraStructs.go
+++ b/jiraStructs.go
@@ -287,11 +287,8 @@ func (item *JiraItem) GetEpicLink() string {
 // GetEstimate returns the estimate of a Jira Item.
 func (item *JiraItem) GetEstimate() int64 {
 	for _, cf := range item.CustomFields {
-		fmt.Println(cf.FieldName)
 		if cf.FieldName == "Story point estimate" {
-			fmt.Println(cf.FieldVales[0])
 			if i, err := strconv.ParseFloat(cf.FieldVales[0], 64); err == nil {
-				fmt.Println(int64(i))
 				return int64(i)
 			}
 			
@@ -303,7 +300,6 @@ func (item *JiraItem) GetEstimate() int64 {
 // GetLastSprint returns the latest sprint a Jira Item was in.
 func (item *JiraItem) GetLastSprint() string {
 	for _, cf := range item.CustomFields {
-		fmt.Println(cf.FieldName)
 		if cf.FieldName == "Sprint" && len(cf.FieldVales) > 0 {
 			return cf.FieldVales[len(cf.FieldVales)-1]
 		}

--- a/jiraStructs.go
+++ b/jiraStructs.go
@@ -216,7 +216,7 @@ func (item *JiraItem) CreateStory(userMaps []userMap) ClubHouseCreateStory {
 		CreatedAt:   	ParseJiraTimeStamp(item.CreatedAtString),
 		UpdatedAt:   	ParseJiraTimeStamp(item.UpdatedAtString),
 		CompletedAt:   	ParseJiraTimeStamp(item.ResolvedAtString),
-		StartedAt:   	ParseJiraTimeStamp(item.ResolvedAtString),
+		StartedAt:   	ParseJiraTimeStampWithDelta(item.ResolvedAtString, -1),
 		Description: 	sanitize.HTML(item.Description),
 		Labels:      	labels,
 		Name:        	sanitize.HTML(item.Summary),
@@ -320,11 +320,16 @@ func (item *JiraItem) GetClubhouseType() string {
 }
 
 // ParseJiraTimeStamp parses the format in the XML using Go's magical timestamp.
-func ParseJiraTimeStamp(dateString string) time.Time {
+func ParseJiraTimeStampWithDelta(dateString string, daysToAdd int) time.Time {
 	format := "Mon, 2 Jan 2006 15:04:05 -0700"
 	t, err := time.Parse(format, dateString)
 	if err != nil {
-		return time.Now()
+		return time.Now().AddDate(0, 0, daysToAdd)
 	}
-	return t
+	return t.AddDate(0, 0, daysToAdd)
+}
+
+// ParseJiraTimeStamp parses the format in the XML using Go's magical timestamp.
+func ParseJiraTimeStamp(dateString string) time.Time {
+	return ParseJiraTimeStampWithDelta(dateString, 0)
 }

--- a/jiraStructs.go
+++ b/jiraStructs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"strconv"
 
 	"github.com/kennygrant/sanitize"
 )
@@ -43,6 +44,8 @@ type JiraItem struct {
 	CustomFields []JiraCustomField `xml:"customfields>customfield"`
 
 	epicLink string
+	UpdatedAtString string   		`xml:"updated"`
+	ResolvedAtString string   		`xml:"resolved"`
 }
 
 //JiraCustomField is the information for custom fields. Right now the only one used is the Epic Link
@@ -142,8 +145,16 @@ func (item *JiraItem) CreateStory(userMaps []userMap) ClubHouseCreateStory {
 	for _, label := range item.Labels {
 		labels = append(labels, ClubHouseCreateLabel{Name: strings.ToLower(label)})
 	}
+
+	// Add a label for tracking jira sprints in 
+	lastSprint := item.GetLastSprint()
+
+	if lastSprint != "" {
+		labels = append(labels, ClubHouseCreateLabel{Name: strings.ToLower(lastSprint)})
+	}
+
 	// Adding special label that indicates that it was imported from JIRA
-	labels = append(labels, ClubHouseCreateLabel{Name: "JIRA"})
+	labels = append(labels, ClubHouseCreateLabel{Name: "jira"})
 
 	// Overwrite supplied Project ID
 	projectID := MapProject(userMaps, item.Assignee.Username)
@@ -203,6 +214,9 @@ func (item *JiraItem) CreateStory(userMaps []userMap) ClubHouseCreateStory {
 	return ClubHouseCreateStory{
 		Comments:    	comments,
 		CreatedAt:   	ParseJiraTimeStamp(item.CreatedAtString),
+		UpdatedAt:   	ParseJiraTimeStamp(item.UpdatedAtString),
+		CompletedAt:   	ParseJiraTimeStamp(item.ResolvedAtString),
+		StartedAt:   	ParseJiraTimeStamp(item.ResolvedAtString),
 		Description: 	sanitize.HTML(item.Description),
 		Labels:      	labels,
 		Name:        	sanitize.HTML(item.Summary),
@@ -213,6 +227,7 @@ func (item *JiraItem) CreateStory(userMaps []userMap) ClubHouseCreateStory {
 		WorkflowState:	state,
 		OwnerIDs:		owners,
 		RequestedBy:	requestor,
+		Estimate: 		item.GetEstimate(),
 	}
 }
 
@@ -264,6 +279,33 @@ func (item *JiraItem) GetEpicLink() string {
 	for _, cf := range item.CustomFields {
 		if cf.FieldName == "Epic Link" {
 			return cf.FieldVales[0]
+		}
+	}
+	return ""
+}
+
+// GetEstimate returns the estimate of a Jira Item.
+func (item *JiraItem) GetEstimate() int64 {
+	for _, cf := range item.CustomFields {
+		fmt.Println(cf.FieldName)
+		if cf.FieldName == "Story point estimate" {
+			fmt.Println(cf.FieldVales[0])
+			if i, err := strconv.ParseFloat(cf.FieldVales[0], 64); err == nil {
+				fmt.Println(int64(i))
+				return int64(i)
+			}
+			
+		}
+	}
+	return 0
+}
+
+// GetLastSprint returns the latest sprint a Jira Item was in.
+func (item *JiraItem) GetLastSprint() string {
+	for _, cf := range item.CustomFields {
+		fmt.Println(cf.FieldName)
+		if cf.FieldName == "Sprint" && len(cf.FieldVales) > 0 {
+			return cf.FieldVales[len(cf.FieldVales)-1]
 		}
 	}
 	return ""

--- a/main.go
+++ b/main.go
@@ -257,7 +257,7 @@ func SendData(token string, data ClubHouseData) error {
 
 // GetURL will get the use the REST API v1 address, the resource provided and the API token to get the URL for transactions
 func GetURL(kind string, token string) string {
-	return fmt.Sprintf("%s%s?token=%s", "https://api.clubhouse.io/api/v1/", kind, token)
+	return fmt.Sprintf("%s%s?token=%s", "https://api.clubhouse.io/api/v2/", kind, token)
 }
 
 // GetDataFromXMLFile will Unmarshal the XML file into the objects used by the application.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/urfave/cli"
 )
@@ -22,7 +23,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "Jira to Clubhouse"
 	app.Usage = "Jira To Clubhouse"
-	app.Version = "0.0.4"
+	app.Version = "0.0.5"
 	app.Commands = []cli.Command{
 		{
 			Name:    "export",
@@ -251,6 +252,9 @@ func SendData(token string, data ClubHouseData) error {
 			fmt.Println("response Body:", string(body))
 			fmt.Println("---------")
 		}
+
+		// CH has a 200 requests / min rate limit
+		time.Sleep(350 * time.Millisecond)
 	}
 	return nil
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2019.3.9
+chardet==3.0.4
+idna==2.8
+requests==2.21.0
+urllib3==1.24.1


### PR DESCRIPTION
This PR also

* Freezes python requirements so it's easy to install in a venv
* upgrades to ch api v2
* Adds fields: updated at, completed at, started at, story points, last sprint tagging. _Note: Started at is faked to be 1 day before completed at because Jira doesn't give a start date_
* Handles CH rate limiting

_Also note: I don't know Go so this was my best shot :)_